### PR TITLE
refactor: rename module

### DIFF
--- a/_example/exec-command/main.go
+++ b/_example/exec-command/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/confluentinc/go-prompt"
 )
 
 func executor(t string) {

--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/confluentinc/go-prompt"
 )
 
 type RequestContext struct {

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/confluentinc/go-prompt"
 )
 
 var LivePrefixState struct {

--- a/_example/simple-echo/cjk-cyrillic/main.go
+++ b/_example/simple-echo/cjk-cyrillic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/confluentinc/go-prompt"
 )
 
 func executor(in string) {

--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/confluentinc/go-prompt"
 )
 
 func completer(in prompt.Document) []prompt.Suggest {

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/completer"
+	prompt "github.com/confluentinc/go-prompt"
+	"github.com/confluentinc/go-prompt/completer"
 )
 
 var filePathCompleter = completer.FilePathCompleter{

--- a/_tools/vt100_debug/main.go
+++ b/_tools/vt100_debug/main.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main
@@ -6,8 +7,8 @@ import (
 	"fmt"
 	"syscall"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/term"
+	prompt "github.com/confluentinc/go-prompt"
+	"github.com/confluentinc/go-prompt/internal/term"
 )
 
 func main() {

--- a/buffer.go
+++ b/buffer.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 )
 
 // Buffer emulates the console buffer.

--- a/completer/file.go
+++ b/completer/file.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/debug"
+	prompt "github.com/confluentinc/go-prompt"
+	"github.com/confluentinc/go-prompt/internal/debug"
 )
 
 var (

--- a/completion.go
+++ b/completion.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/document.go
+++ b/document.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
-	"github.com/c-bata/go-prompt/internal/debug"
-	istrings "github.com/c-bata/go-prompt/internal/strings"
+	"github.com/confluentinc/go-prompt/internal/bisect"
+	"github.com/confluentinc/go-prompt/internal/debug"
+	istrings "github.com/confluentinc/go-prompt/internal/strings"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/emacs.go
+++ b/emacs.go
@@ -1,6 +1,6 @@
 package prompt
 
-import "github.com/c-bata/go-prompt/internal/debug"
+import "github.com/confluentinc/go-prompt/internal/debug"
 
 /*
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/c-bata/go-prompt
+module github.com/confluentinc/go-prompt
 
 go 1.19
 

--- a/input_posix.go
+++ b/input_posix.go
@@ -6,7 +6,7 @@ package prompt
 import (
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/term"
+	"github.com/confluentinc/go-prompt/internal/term"
 	"golang.org/x/sys/unix"
 )
 

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
+	"github.com/confluentinc/go-prompt/internal/bisect"
 )
 
 func Example() {

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -3,7 +3,7 @@ package strings_test
 import (
 	"fmt"
 
-	"github.com/c-bata/go-prompt/internal/strings"
+	"github.com/confluentinc/go-prompt/internal/strings"
 )
 
 func ExampleIndexNotByte() {

--- a/prompt.go
+++ b/prompt.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 )
 
 // Executor is called when user input something text.

--- a/render.go
+++ b/render.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/signal_posix.go
+++ b/signal_posix.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/confluentinc/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {


### PR DESCRIPTION
This PR changes the module name in go.mod from "github.com/c-bata/go-prompt" to "github.com/confluentinc/go-prompt" and adjusts all other files that use this name. 

We need the module defined in go.mod to match the repo name, otherwise we get an error when running `go get github.com/confluentinc/go-prompt` in other projects.