### PR TITLE
Fix multiline buffer rendering

### DIFF
--- a/render.go
+++ b/render.go
@@ -57,10 +57,11 @@ func (r *Render) getCurrentPrefix() string {
 	return r.prefix
 }
 
-func (r *Render) renderPrefix() {
+func (r *Render) renderPrefix() int {
 	r.out.SetColor(r.prefixTextColor, r.prefixBGColor, false)
 	r.out.WriteStr(r.getCurrentPrefix())
 	r.out.SetColor(DefaultColor, DefaultColor, false)
+	return r.getCursorEndPos(r.getCurrentPrefix(), 0)
 }
 
 // TearDown to clear title and erasing.
@@ -92,7 +93,7 @@ func (r *Render) renderWindowTooSmall() {
 	r.out.WriteStr("Your console window is too small...")
 }
 
-func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
+func (r *Render) renderCompletion(completions *CompletionManager, cursorPos int) {
 	suggestions := completions.GetSuggestions()
 	if len(completions.GetSuggestions()) == 0 {
 		return
@@ -112,7 +113,7 @@ func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
 	formatted = formatted[completions.verticalScroll : completions.verticalScroll+windowHeight]
 	r.prepareArea(windowHeight)
 
-	cursor := runewidth.StringWidth(prefix) + runewidth.StringWidth(buf.Document().TextBeforeCursor())
+	cursor := cursorPos
 	x, _ := r.toPos(cursor)
 	if x+width >= int(r.col) {
 		cursor = r.backward(cursor, x+width-int(r.col))
@@ -184,10 +185,13 @@ func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, 
 	}
 	defer func() { debug.AssertNoError(r.out.Flush()) }()
 
+	cursorPos := r.previousCursor
+
+	prefix := r.getCurrentPrefix()
 	line := buffer.Text()
 
 	// Down, ControlN
-	traceBackLines := strings.Count(previousText, "\n")
+	traceBackLines := cursorPos / int(r.col) // calculate number of lines we had before
 	// if the new buffer is empty and we are not browsing the history using the Down/controlDown keys
 	// then we reset the traceBackLines to 0 since there's nothing to trace back/erase.
 	if len(line) == 0 && lastKeyStroke != ControlDown && lastKeyStroke != Down {
@@ -196,51 +200,35 @@ func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, 
 	debug.Log(fmt.Sprintln(line))
 	debug.Log(fmt.Sprintln(traceBackLines))
 
-	r.move((traceBackLines)*int(r.col)+r.previousCursor, 0)
-
-	prefix := r.getCurrentPrefix()
-	cursor := runewidth.StringWidth(prefix) + runewidth.StringWidth(line)
-
-	// prepare area
-	_, y := r.toPos((traceBackLines + int(r.col)) + cursor)
-
+	// prepare area by getting the end position the console cursor will be at after rendering
+	cursorEndPos := r.getCursorEndPos(prefix+line, 0)
+	_, y := r.toPos(cursorEndPos)
 	h := y + 1 + int(completion.max)
 	if h > int(r.row) || completionMargin > int(r.col) {
 		r.renderWindowTooSmall()
 		return traceBackLines
 	}
 
-	// Rendering
-	r.out.HideCursor()
+	// Clear screen
+	cursorPos = r.clear(cursorPos)
 
-	r.out.EraseLine()
-	r.out.EraseDown()
-	r.renderPrefix()
-
+	// Render new text
+	cursorPos += r.renderPrefix()
+	r.out.SetColor(DefaultColor, DefaultColor, false)
+	cursorPos += r.renderLine(line, lexer, cursorPos)
 	r.out.SetColor(DefaultColor, DefaultColor, false)
 
-	r.lineWrap(cursor)
-
-	if buffer.NewLineCount() > 0 {
-		r.renderMultiline(buffer, lexer)
-	} else {
-		r.renderLine(line, lexer)
-		defer r.out.ShowCursor()
-	}
-
-	r.lineWrap(cursor)
-	r.out.SetColor(DefaultColor, DefaultColor, false)
-
-	cursor = r.backward(cursor, runewidth.StringWidth(line)-buffer.DisplayCursorPosition())
-
-	r.renderCompletion(buffer, completion)
+	// Translate buffer cursor position into console cursor position
+	cursorPosInBuffer := r.getCursorEndPos(prefix+line[:buffer.Document().cursorPosition], 0)
+	cursorPos = r.move(cursorPos, cursorPosInBuffer)
 	if suggest, ok := completion.GetSelectedSuggestion(); ok {
-		cursor = r.backward(cursor, runewidth.StringWidth(buffer.Document().GetWordBeforeCursorUntilSeparator(completion.wordSeparator)))
+		cursorPos = r.backward(cursorPos, runewidth.StringWidth(buffer.Document().GetWordBeforeCursorUntilSeparator(completion.wordSeparator)))
 
 		r.out.SetColor(r.previewSuggestionTextColor, r.previewSuggestionBGColor, false)
 		r.out.WriteStr(suggest.Text)
 		r.out.SetColor(DefaultColor, DefaultColor, false)
-		cursor += runewidth.StringWidth(suggest.Text)
+		cursorPos += runewidth.StringWidth(suggest.Text)
+		cursorPosBehindSuggestion := cursorPos
 
 		rest := buffer.Document().TextAfterCursor()
 
@@ -259,20 +247,18 @@ func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, 
 		} else {
 			r.out.WriteStr(rest)
 		}
-
+		cursorEndPosWithInsertedSuggestion := r.getCursorEndPos(rest, cursorPos)
 		r.out.SetColor(DefaultColor, DefaultColor, false)
 
-		cursor += runewidth.StringWidth(rest)
-		r.lineWrap(cursor)
-
-		cursor = r.backward(cursor, runewidth.StringWidth(rest))
+		cursorPos = r.move(cursorEndPosWithInsertedSuggestion, cursorPosBehindSuggestion)
 	}
-	r.previousCursor = cursor
+	r.renderCompletion(completion, cursorPos)
+	r.previousCursor = cursorPos
 
 	return traceBackLines
 }
 
-func (r *Render) renderLine(line string, lexer *Lexer) {
+func (r *Render) renderLine(line string, lexer *Lexer, cursorPos int) int {
 	if lexer.IsEnabled {
 		processed := lexer.Process(line)
 		var s = line
@@ -288,39 +274,13 @@ func (r *Render) renderLine(line string, lexer *Lexer) {
 		r.out.SetColor(r.inputTextColor, r.inputBGColor, false)
 		r.out.WriteStr(line)
 	}
-}
-
-func (r *Render) renderMultiline(buffer *Buffer, lexer *Lexer) {
-	before := buffer.Document().TextBeforeCursor()
-	cursor := ""
-	after := ""
-
-	if len(buffer.Document().TextAfterCursor()) == 0 {
-		cursor = " "
-		after = ""
-	} else {
-		cursor = string(buffer.Text()[buffer.Document().cursorPosition])
-		if cursor == "\n" {
-			cursor = " \n"
-		}
-		after = buffer.Document().TextAfterCursor()[1:]
-	}
-
-	r.out.SetColor(r.inputTextColor, r.inputBGColor, false)
-	r.renderLine(before, lexer)
-
-	r.out.SetDisplayAttributes(r.inputTextColor, r.inputBGColor, DisplayReverse)
-	r.out.WriteRawStr(cursor)
-
-	r.out.SetColor(r.inputTextColor, r.inputBGColor, false)
-	r.renderLine(after, lexer)
+	return r.getCursorEndPos(line, cursorPos) - cursorPos
 }
 
 // BreakLine to break line.
 func (r *Render) BreakLine(buffer *Buffer, lexer *Lexer) {
 	// Erasing and Render
-	cursor := (buffer.NewLineCount() * int(r.col)) + runewidth.StringWidth(buffer.Document().TextBeforeCursor()) + runewidth.StringWidth(r.getCurrentPrefix())
-	r.clear(cursor)
+	r.clear(r.getCursorEndPos(r.getCurrentPrefix()+buffer.Document().TextBeforeCursor(), 0))
 
 	r.renderPrefix()
 
@@ -351,11 +311,26 @@ func (r *Render) BreakLine(buffer *Buffer, lexer *Lexer) {
 	r.previousCursor = 0
 }
 
+func (r *Render) getCursorEndPos(text string, startPos int) int {
+	lines := strings.SplitAfter(text, "\n")
+	cursor := startPos
+	for _, line := range lines {
+		filledCols := runewidth.StringWidth(line)
+		cursor += filledCols
+		if len(line) > 0 && line[len(line)-1:] == "\n" {
+			remainingChars := int(r.col) - (cursor % int(r.col))
+			cursor += remainingChars
+		}
+	}
+	return cursor
+}
+
 // clear erases the screen from a beginning of input
 // even if there is line break which means input length exceeds a window's width.
-func (r *Render) clear(cursor int) {
+func (r *Render) clear(cursor int) int {
 	r.move(cursor, 0)
 	r.out.EraseDown()
+	return 0
 }
 
 // backward moves cursor to backward from a current cursor position

--- a/render_test.go
+++ b/render_test.go
@@ -4,6 +4,8 @@
 package prompt
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 )
@@ -156,18 +158,18 @@ func TestLinesToTracebackRender(t *testing.T) {
 		selectedDescriptionBGColor:   Cyan,
 		scrollbarThumbColor:          DarkGray,
 		scrollbarBGColor:             Cyan,
-		col:                          1,
+		col:                          100,
+		row:                          100,
 	}
 
-	for _, s := range scenarios {
+	for idx, s := range scenarios {
+		fmt.Printf("Testing scenario: %v\n", idx)
 		b := NewBuffer()
 		b.InsertText(s.nextText, false, true)
 		l := NewLexer()
 
+		r.previousCursor = r.getCursorEndPos(s.previousText, 0)
 		tracedBackLines := r.Render(b, s.previousText, s.lastKey, NewCompletionManager(emptyCompleter, 0), l)
-
-		if tracedBackLines != s.linesToTraceBack {
-			t.Errorf("Should've traced back %d lines before rendering, but got %d", s.linesToTraceBack, tracedBackLines)
-		}
+		require.Equal(t, s.linesToTraceBack, tracedBackLines)
 	}
 }

--- a/render_test.go
+++ b/render_test.go
@@ -173,3 +173,54 @@ func TestLinesToTracebackRender(t *testing.T) {
 		require.Equal(t, s.linesToTraceBack, tracedBackLines)
 	}
 }
+
+func TestGetCursorEndPosition(t *testing.T) {
+	r := &Render{
+		prefix:                       "> ",
+		out:                          &PosixWriter{},
+		livePrefixCallback:           func() (string, bool) { return "", false },
+		prefixTextColor:              Blue,
+		prefixBGColor:                DefaultColor,
+		inputTextColor:               DefaultColor,
+		inputBGColor:                 DefaultColor,
+		previewSuggestionTextColor:   Green,
+		previewSuggestionBGColor:     DefaultColor,
+		suggestionTextColor:          White,
+		suggestionBGColor:            Cyan,
+		selectedSuggestionTextColor:  Black,
+		selectedSuggestionBGColor:    Turquoise,
+		descriptionTextColor:         Black,
+		descriptionBGColor:           Turquoise,
+		selectedDescriptionTextColor: White,
+		selectedDescriptionBGColor:   Cyan,
+		scrollbarThumbColor:          DarkGray,
+		scrollbarBGColor:             Cyan,
+		col:                          5,
+		row:                          10,
+	}
+
+	scenarios := []struct {
+		text                 string
+		startPos             int
+		expectedCursorEndPos int
+	}{
+		{text: "abc", startPos: 0, expectedCursorEndPos: 3},
+		{text: "abcd", startPos: 0, expectedCursorEndPos: 4},
+		{text: "abcde", startPos: 0, expectedCursorEndPos: 5},
+		{text: "abc\n", startPos: 0, expectedCursorEndPos: 5},
+		{text: "abc\n\n", startPos: 0, expectedCursorEndPos: 10},
+		{text: "abc\nd", startPos: 0, expectedCursorEndPos: 6},
+		{text: "ab\nc", startPos: 0, expectedCursorEndPos: 6},
+		{text: "ab\n\nc", startPos: 0, expectedCursorEndPos: 11},
+		{text: "ab\n\nc", startPos: 2, expectedCursorEndPos: 11},
+		{text: "ab\n\nc", startPos: 3, expectedCursorEndPos: 16},
+		{text: "ab\n\ncdefghijk", startPos: 3, expectedCursorEndPos: 24},
+	}
+
+	for idx, s := range scenarios {
+		fmt.Printf("Testing scenario: %v\n", idx)
+		actualEndPos := r.getCursorEndPos(s.text, s.startPos)
+		require.Equal(t, s.expectedCursorEndPos, actualEndPos)
+	}
+
+}


### PR DESCRIPTION
The multiline buffer was not using the console cursor correctly, which led to multiple rendering bugs e.g. when trying to insert a suggestion in a line that's not the last line. It was also not working correctly when there was a need to wrap the line due to the text being too long for the output window.

This PR refactors this behavior. The main thing to make this work is to keep track of the cursor end position when printing something (e.g. when you write the string "ABC", the cursor position moves by 3). The reason we need to keep track of the cursor position is that whenever you want to move the cursor to a target position, you need to know the start position to calculate the moves you have to make to get to the target position. To simplify this a bit, I introduced a function that takes in a string and a starting cursor position and calculates the correct ending position of the cursor after printing the given string. This function takes line breaks and wrapping lines into account.