### PR TITLE
feat: make it possible to paste multiline statements

### DIFF
--- a/input.go
+++ b/input.go
@@ -45,6 +45,10 @@ func RemoveASCIISequences(input []byte) []byte {
 		})
 	})
 	for _, specialSequence := range ASCIISequences {
+		// skip \n and \r because those are valid input
+		if specialSequence.Key == Enter || specialSequence.Key == ControlM {
+			continue
+		}
 		input = bytes.ReplaceAll(input, specialSequence.ASCIICode, []byte{})
 	}
 	return input


### PR DESCRIPTION
Pasting multiline statements from the clipboard doesn't work at the moment, because we clean the input of any ASCII sequence before inserting. This includes \n and \r. 
For now skipping those should be sufficient but if more exceptions like this pop up, we should consider keeping a separate list for sequences that we want to remove.