### PR TITLE
Bugfix/kfs 698 prevent cursor from moving out of viewport

### DIFF
--- a/render.go
+++ b/render.go
@@ -174,6 +174,20 @@ func (r *Render) ClearScreen() {
 	r.out.CursorGoTo(0, 0)
 }
 
+// checks if the buffer cursor is out of the viewport height after rendering
+func (r *Render) isCursorOutOfViewAfterMoveUp(buffer *Buffer) bool {
+	prefix := r.getCurrentPrefix()
+	line := buffer.Text()
+	cursorEndPos := r.getCursorEndPos(prefix+line, 0)
+	_, lastLineY := r.toPos(cursorEndPos)
+
+	currentLineY := buffer.Document().CursorPositionRow()
+	if currentLineY-1 < 0 || lastLineY-(currentLineY-1) >= int(r.row) {
+		return true
+	}
+	return false
+}
+
 // Render renders to the console.
 func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, completion *CompletionManager, lexer *Lexer) (tracedBackLines int) {
 
@@ -199,12 +213,6 @@ func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, 
 
 	// prepare area by getting the end position the console cursor will be at after rendering
 	cursorEndPos := r.getCursorEndPos(prefix+line, 0)
-	_, y := r.toPos(cursorEndPos)
-	h := y + 1 + int(completion.max)
-	if h > int(r.row) || completionMargin > int(r.col) {
-		r.renderWindowTooSmall()
-		return traceBackLines
-	}
 
 	// Clear screen
 	r.clear(r.previousCursor)

--- a/render_test.go
+++ b/render_test.go
@@ -222,5 +222,51 @@ func TestGetCursorEndPosition(t *testing.T) {
 		actualEndPos := r.getCursorEndPos(s.text, s.startPos)
 		require.Equal(t, s.expectedCursorEndPos, actualEndPos)
 	}
+}
 
+func TestIsCursorUpPossible(t *testing.T) {
+	scenarios := []struct {
+		text         string
+		countMovesUp int
+		expected     bool
+	}{
+		{text: "first line\nsecond line", countMovesUp: 0, expected: false},
+		{text: "first line\nsecond line", countMovesUp: 1, expected: true},
+		{text: "first line\nsecond line\nthird line", countMovesUp: 0, expected: false},
+		{text: "first line\nsecond line\nthird line", countMovesUp: 1, expected: true},
+		{text: "first line\nsecond line\nthird line", countMovesUp: 2, expected: true},
+		{text: "first line\nsecond line\nthird line", countMovesUp: 3, expected: true},
+	}
+
+	r := &Render{
+		prefix:                       "> ",
+		out:                          &PosixWriter{},
+		livePrefixCallback:           func() (string, bool) { return "", false },
+		prefixTextColor:              Blue,
+		prefixBGColor:                DefaultColor,
+		inputTextColor:               DefaultColor,
+		inputBGColor:                 DefaultColor,
+		previewSuggestionTextColor:   Green,
+		previewSuggestionBGColor:     DefaultColor,
+		suggestionTextColor:          White,
+		suggestionBGColor:            Cyan,
+		selectedSuggestionTextColor:  Black,
+		selectedSuggestionBGColor:    Turquoise,
+		descriptionTextColor:         Black,
+		descriptionBGColor:           Turquoise,
+		selectedDescriptionTextColor: White,
+		selectedDescriptionBGColor:   Cyan,
+		scrollbarThumbColor:          DarkGray,
+		scrollbarBGColor:             Cyan,
+		col:                          100,
+		row:                          2,
+	}
+
+	for idx, s := range scenarios {
+		fmt.Printf("Testing scenario: %v\n", idx)
+		b := NewBuffer()
+		b.InsertText(s.text, false, true)
+		b.CursorUp(s.countMovesUp)
+		require.Equal(t, s.expected, r.isCursorOutOfViewAfterMoveUp(b))
+	}
 }


### PR DESCRIPTION
Closed in favour of this PR: #8 

This prevents moving the cursor up a line if this would mean that the cursor ends up outside of the viewport. 
With this fix it should no longer be possible to have mismatching positions between the buffer and the console cursor.