### PR TITLE
KFS-698: refactor: change the window too small message rendering

### DIFF
--- a/render.go
+++ b/render.go
@@ -85,11 +85,10 @@ func (r *Render) UpdateWinSize(ws *WinSize) {
 	r.col = ws.Col
 }
 
-func (r *Render) renderWindowTooSmall() {
+func (r *Render) renderWindowTooSmall(msg string) {
 	r.out.CursorGoTo(0, 0)
 	r.out.EraseScreen()
-	r.out.SetColor(DarkRed, White, false)
-	r.out.WriteStr("Your console window is too small...")
+	r.out.WriteStr(msg)
 }
 
 func (r *Render) renderCompletion(completions *CompletionManager, cursorPos int) {
@@ -202,7 +201,9 @@ func (r *Render) Render(buffer *Buffer, previousText string, lastKeyStroke Key, 
 	_, y := r.toPos(cursorEndPos)
 	h := y + 1 + int(completion.max)
 	if h > int(r.row) || completionMargin > int(r.col) {
-		r.renderWindowTooSmall()
+		windowTooSmallMsg := "Your console window is too small, please delete some lines..."
+		r.renderWindowTooSmall(windowTooSmallMsg)
+		r.previousCursor = r.getCursorEndPos(windowTooSmallMsg, 0)
 		return traceBackLines
 	}
 


### PR DESCRIPTION
Changes the window too small function to take in a message that should be displayed and adjusts the printed color. 
We now also account for the cursor position, after rendering the message. This should prevent a case where the message is not cleared correctly.