### PR TITLE
KFS-840: feat: set enter as default statement terminator

### DIFF
--- a/option.go
+++ b/option.go
@@ -317,6 +317,13 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 		lexer:       NewLexer(),
 		completion:  NewCompletionManager(completer, 6),
 		keyBindMode: EmacsKeyBind, // All the above assume that bash is running in the default Emacs setting
+		statementTerminatorCb: func(lastKeyStroke Key, buffer *Buffer) bool {
+			// terminate statement on enter which is either \r or \n, based on OS
+			if lastKeyStroke == ControlM || lastKeyStroke == Enter {
+				return true
+			}
+			return false
+		},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Set enter as the default statement terminator. This means that by default the multi line buffer will be disabled, making it possible for other repos that have used the original go-prompt to continue using it in the expected way.