### PR TITLE
fix: races and selected completion idx out of bounds bug

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -52,6 +52,7 @@ func (c *CompletionManager) GetSelectedSuggestion() (s Suggest, ok bool) {
 	} else if c.selected < -1 || c.selected >= len(c.tmp) {
 		debug.Assert(false, "must not reach here")
 		c.selected = -1
+		c.verticalScroll = 0
 		return Suggest{}, false
 	}
 
@@ -76,11 +77,13 @@ func (c *CompletionManager) GetSelectedIdx() int {
 func (c *CompletionManager) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.reset()
+}
 
+func (c *CompletionManager) reset() {
 	c.selected = -1
 	c.verticalScroll = 0
-	updatedSuggestions := c.completer(*NewDocument())
-	c.tmp = updatedSuggestions
+	c.tmp = []Suggest{}
 }
 
 // Update to update the suggestions.
@@ -90,7 +93,7 @@ func (c *CompletionManager) Update(in Document) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.selected = -1
+	c.reset()
 	c.tmp = updatedSuggestions
 }
 
@@ -134,10 +137,7 @@ func (c *CompletionManager) update() {
 	}
 
 	if c.selected >= lenSuggestions {
-		c.selected = -1
-		c.verticalScroll = 0
-		updatedSuggestions := c.completer(*NewDocument())
-		c.tmp = updatedSuggestions
+		c.reset()
 	} else if c.selected < -1 {
 		c.selected = lenSuggestions - 1
 		c.verticalScroll = lenSuggestions - max

--- a/completion.go
+++ b/completion.go
@@ -44,16 +44,16 @@ type CompletionManager struct {
 
 // GetSelectedSuggestion returns the selected item.
 func (c *CompletionManager) GetSelectedSuggestion() (s Suggest, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.selected == -1 {
 		return Suggest{}, false
-	} else if c.selected < -1 {
+	} else if c.selected < -1 || c.selected >= len(c.tmp) {
 		debug.Assert(false, "must not reach here")
 		c.selected = -1
 		return Suggest{}, false
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	return c.tmp[c.selected], true
 }
@@ -65,11 +65,22 @@ func (c *CompletionManager) GetSuggestions() []Suggest {
 	return c.tmp
 }
 
+// GetSuggestions returns the list of suggestion.
+func (c *CompletionManager) GetSelectedIdx() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.selected
+}
+
 // Reset to select nothing.
 func (c *CompletionManager) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.selected = -1
 	c.verticalScroll = 0
-	c.Update(*NewDocument())
+	updatedSuggestions := c.completer(*NewDocument())
+	c.tmp = updatedSuggestions
 }
 
 // Update to update the suggestions.
@@ -79,11 +90,15 @@ func (c *CompletionManager) Update(in Document) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.selected = -1
 	c.tmp = updatedSuggestions
 }
 
 // Previous to select the previous suggestion item.
 func (c *CompletionManager) Previous() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.verticalScroll == c.selected && c.selected > 0 {
 		c.verticalScroll--
 	}
@@ -93,6 +108,9 @@ func (c *CompletionManager) Previous() {
 
 // Next to select the next suggestion item.
 func (c *CompletionManager) Next() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.verticalScroll+int(c.max)-1 == c.selected {
 		c.verticalScroll++
 	}
@@ -102,18 +120,24 @@ func (c *CompletionManager) Next() {
 
 // Completing returns whether the CompletionManager selects something one.
 func (c *CompletionManager) Completing() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.selected != -1
 }
 
 func (c *CompletionManager) update() {
 	max := int(c.max)
-	lenSuggestions := len(c.GetSuggestions())
+	lenSuggestions := len(c.tmp)
 	if lenSuggestions < max {
 		max = lenSuggestions
 	}
 
 	if c.selected >= lenSuggestions {
-		c.Reset()
+		c.selected = -1
+		c.verticalScroll = 0
+		updatedSuggestions := c.completer(*NewDocument())
+		c.tmp = updatedSuggestions
 	} else if c.selected < -1 {
 		c.selected = lenSuggestions - 1
 		c.verticalScroll = lenSuggestions - max

--- a/prompt.go
+++ b/prompt.go
@@ -173,10 +173,13 @@ func (p *Prompt) Input() string {
 				return e.input
 			} else {
 				document := *p.buf.Document()
-				go func() {
-					p.completion.Update(document)
-					completionCh <- true
-				}()
+				// we don't want to trigger completions again while navigating existing completions
+				if !p.completion.Completing() {
+					go func() {
+						p.completion.Update(document)
+						completionCh <- true
+					}()
+				}
 				p.renderer.Render(p.buf, p.prevText, p.lastKey, p.completion, p.lexer)
 			}
 		case w := <-winSizeCh:

--- a/render.go
+++ b/render.go
@@ -129,7 +129,7 @@ func (r *Render) renderCompletion(completions *CompletionManager, cursorPos int)
 		return scrollbarTop <= row && row <= scrollbarTop+scrollbarHeight
 	}
 
-	selected := completions.selected - completions.verticalScroll
+	selected := completions.GetSelectedIdx() - completions.verticalScroll
 	r.out.SetColor(White, Cyan, false)
 	for i := 0; i < windowHeight; i++ {
 		r.out.CursorDown(1)


### PR DESCRIPTION
Make sure all of completion.go is synchronized/locked correctly and fix an index ouf of bound issue. This was happening because navigating completions triggered another call to updateCompletions. So what happened was:
- there is a given list of completions
- you press tab to select the first, which will increment the selected idx from -1 to 0
- now the tab press will also trigger an updateCompletions call
- if that call now returns a list different in size than the initial call, you have a problem
- e.g. an empty list is returned and now we try to access an empty list at index 0

To fix it, I did several things:
- make sure we always reset the selected idx when completions are updated
- make sure we don't trigger completions again and again when navigating a given completion list
- add bounds checks when accessing the completion list at the selected idx, just to be safe