### PR TITLE
feat: add AltEnter shortcut as command termination trigger

### DIFF
--- a/input.go
+++ b/input.go
@@ -92,6 +92,8 @@ var ASCIISequences = []*ASCIICode{
 	{Key: ControlUnderscore, ASCIICode: []byte{0x1f}},
 	{Key: Backspace, ASCIICode: []byte{0x7f}},
 
+	{Key: AltEnter, ASCIICode: []byte{0x1b, 0xd}},
+
 	{Key: Up, ASCIICode: []byte{0x1b, 0x5b, 0x41}},
 	{Key: Down, ASCIICode: []byte{0x1b, 0x5b, 0x42}},
 	{Key: Right, ASCIICode: []byte{0x1b, 0x5b, 0x43}},

--- a/input_test.go
+++ b/input_test.go
@@ -50,14 +50,20 @@ func TestSanitizeInputWithASCIISequences(t *testing.T) {
 			//append 1-5 ascii control sequences
 			sequences := rapid.SliceOfN(RandomASCIIByteSequence(), 1, 5).Draw(t, "random number of ascii control sequences")
 			for _, sequence := range sequences {
-				// allow \n and \r to be inserted
+				// skip those because having them can lead to weird test interactions, e.g. when we generated an Escape
+				// in front of a ControlM, which is the same sequence as AltEnter and will get filtered out
 				if sequence.Key == Enter || sequence.Key == ControlM {
-					expectedString = append(expectedString, sequence.ASCIICode...)
+					continue
 				}
-
 				inputString = append(inputString, sequence.ASCIICode...)
 			}
 		}
 		assert.Equal(t, string(expectedString), string(RemoveASCIISequences(inputString)))
 	})
+}
+
+func TestSanitizeInputWithASCIISequencesDoesNotRemoveControlMAndEnter(t *testing.T) {
+	// shouldn't remove all the line breaks
+	expectedString := "this_is\n\r_a_lon\r\nger_size\r\rd_text_inp\n\nu_f\nor_testi\rg_purposes"
+	assert.Equal(t, expectedString, string(RemoveASCIISequences([]byte(expectedString))))
 }

--- a/key.go
+++ b/key.go
@@ -54,6 +54,8 @@ const (
 	ControlUp
 	ControlDown
 
+	AltEnter
+
 	Up
 	Down
 	Right

--- a/prompt.go
+++ b/prompt.go
@@ -262,7 +262,7 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 	p.handleCompletionKeyBinding(key, completing)
 
 	switch key {
-	case Enter, ControlJ, ControlM:
+	case Enter, ControlJ, ControlM, AltEnter:
 		if p.statementTerminatorCb == nil || !p.statementTerminatorCb(p.buf.lastKeyStroke, p.buf) {
 			p.buf.NewLine(false)
 		} else {


### PR DESCRIPTION
We want to be able to terminate statements with Alt + Enter as well