### PR TITLE
[DP-13434] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,5 +14,3 @@ blocks:
             - checkout
             - "curl -sL https://git.io/autotag-install | sh --"
             - "git push https://confluentinc:$GH_TOKEN@github.com/confluentinc/go-prompt.git v$(./bin/autotag)"
-      secrets:
-        - name: semantic-release-credentials-go-prompt


### PR DESCRIPTION
## Background
This PR is a followup to DP-12820 to clean up Semaphore pipelines. It brings the pipeline up to the latest standards by:
* removing unnecessary commands and secrets
* replacing deprecated commands and secrets with active ones

The vast majority of these secrets and commands are now set automatically on the Semaphore agents, so there is no need to set them specifically in the pipeline. The ones that remain are the ones that are not used globally and are specific to the pipeline's use case.

## Actions
Please approve and merge this change. If status checks are failing, please debug as necessary.
