### PR TITLE
[KFS-1676] return error instead of panicking

### DIFF
--- a/_example/diagnostics/main.go
+++ b/_example/diagnostics/main.go
@@ -77,7 +77,7 @@ func Lexer(line string) []prompt.LexerElement {
 }
 
 func main() {
-	p := prompt.New(nil, completer,
+	p, _ := prompt.New(nil, completer,
 		prompt.OptionTitle("sql-prompt"),
 		prompt.OptionHistory([]string{"SELECT * FROM users;"}),
 		prompt.OptionPrefixTextColor(prompt.Yellow),

--- a/_example/exec-command/main.go
+++ b/_example/exec-command/main.go
@@ -25,7 +25,7 @@ func completer(t prompt.Document) []prompt.Suggest {
 }
 
 func main() {
-	p := prompt.New(
+	p, _ := prompt.New(
 		executor,
 		completer,
 	)

--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -181,7 +181,7 @@ func main() {
 		client: &http.Client{},
 	}
 
-	p := prompt.New(
+	p, _ := prompt.New(
 		executor,
 		completer,
 		prompt.OptionPrefix(u.String()+"> "),

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -37,7 +37,7 @@ func changeLivePrefix() (string, bool) {
 }
 
 func main() {
-	p := prompt.New(
+	p, _ := prompt.New(
 		executor,
 		completer,
 		prompt.OptionPrefix(">>> "),

--- a/_example/simple-echo/multiwidth-completions/main.go
+++ b/_example/simple-echo/multiwidth-completions/main.go
@@ -21,7 +21,7 @@ func completer(in prompt.Document) []prompt.Suggest {
 }
 
 func main() {
-	p := prompt.New(
+	p, _ := prompt.New(
 		executor,
 		completer,
 		prompt.OptionPrefix(">>> "),

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -33,7 +33,7 @@ func completerFunc(d prompt.Document) []prompt.Suggest {
 }
 
 func main() {
-	p := prompt.New(
+	p, _ := prompt.New(
 		executor,
 		completerFunc,
 		prompt.OptionPrefix(">>> "),

--- a/input_posix.go
+++ b/input_posix.go
@@ -64,13 +64,13 @@ func (t *PosixParser) GetWinSize() *WinSize {
 var _ ConsoleParser = &PosixParser{}
 
 // NewStandardInputParser returns ConsoleParser object to read from stdin.
-func NewStandardInputParser() *PosixParser {
+func NewStandardInputParser() (*PosixParser, error) {
 	in, err := syscall.Open("/dev/tty", syscall.O_RDONLY, 0)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &PosixParser{
 		fd: in,
-	}
+	}, nil
 }

--- a/input_windows.go
+++ b/input_windows.go
@@ -78,6 +78,6 @@ func (p *WindowsParser) GetWinSize() *WinSize {
 }
 
 // NewStandardInputParser returns ConsoleParser object to read from stdin.
-func NewStandardInputParser() *WindowsParser {
-	return &WindowsParser{}
+func NewStandardInputParser() (*WindowsParser, error) {
+	return &WindowsParser{}, nil
 }

--- a/option.go
+++ b/option.go
@@ -316,12 +316,16 @@ func OptionSetStatementTerminator(fn StatementTerminatorCb) Option {
 }
 
 // New returns a Prompt with powerful auto-completion.
-func New(executor Executor, completer Completer, opts ...Option) IPrompt {
+func New(executor Executor, completer Completer, opts ...Option) (IPrompt, error) {
 	defaultWriter := NewStdoutWriter()
 	registerConsoleWriter(defaultWriter)
 
+	standardInputParser, err := NewStandardInputParser()
+	if err != nil {
+		return nil, err
+	}
 	pt := &Prompt{
-		in: NewStandardInputParser(),
+		in: standardInputParser,
 		renderer: &Render{
 			prefix:                       "> ",
 			out:                          defaultWriter,
@@ -363,8 +367,8 @@ func New(executor Executor, completer Completer, opts ...Option) IPrompt {
 
 	for _, opt := range opts {
 		if err := opt(pt); err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
-	return pt
+	return pt, nil
 }

--- a/shortcut.go
+++ b/shortcut.go
@@ -4,13 +4,17 @@ func dummyExecutor(in string) {}
 
 // Input get the input data from the user and return it.
 func Input(prefix string, completer Completer, opts ...Option) string {
-	pt := New(dummyExecutor, completer)
+	pt, err := New(dummyExecutor, completer)
+	if err != nil {
+		return ""
+	}
+
 	pt.Renderer().prefixTextColor = DefaultColor
 	pt.Renderer().prefix = prefix
 
 	for _, opt := range opts {
 		if err := opt(pt); err != nil {
-			panic(err)
+			return ""
 		}
 	}
 	return pt.Input()
@@ -20,7 +24,10 @@ func Input(prefix string, completer Completer, opts ...Option) string {
 // Deprecated: Maybe anyone want to use this.
 func Choose(prefix string, choices []string, opts ...Option) string {
 	completer := newChoiceCompleter(choices, FilterHasPrefix)
-	pt := New(dummyExecutor, completer)
+	pt, err := New(dummyExecutor, completer)
+	if err != nil {
+		return ""
+	}
 	pt.Renderer().prefixTextColor = DefaultColor
 	pt.Renderer().prefix = prefix
 


### PR DESCRIPTION
We should return an error in `NewStandardInputParser()` instead of panicking, same for `New() `