### PR TITLE
Revert "Fix Ctrl+C"

### DIFF
--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -25,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -10,18 +10,16 @@ import (
 )
 
 var (
-	saveTermios     unix.Termios
+	saveTermios     *unix.Termios
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (unix.Termios, error) {
+func getOriginalTermios(fd int) (*unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
-		var saveTermiosPtr *unix.Termios
-		saveTermiosPtr, err = termios.Tcgetattr(uintptr(fd))
-		saveTermios = *saveTermiosPtr
+		saveTermios, err = termios.Tcgetattr(uintptr(fd))
 	})
 	return saveTermios, err
 }
@@ -32,5 +30,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
 }


### PR DESCRIPTION
Reverts confluentinc/go-prompt#34 

This breaks listening for CtrlC and other cancellation events in the flink shell