### PR TITLE
Fix/KFS-2330 move multiline escape closes completion

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -180,6 +180,17 @@ func (b *Buffer) JoinNextLine(separator string) {
 	}
 }
 
+// If this is a multiline buffer and the cursor is not at the top line
+func (b *Buffer) HasPrevLine() bool {
+	return b.NewLineCount() > 0 && b.Document().CursorPositionRow() > 0
+}
+
+// If this is a multiline buffer and the cursor is not at the last line
+func (b *Buffer) HasNextLine() bool {
+	newLineCount := b.NewLineCount()
+	return newLineCount > 0 && b.Document().CursorPositionRow() < newLineCount
+}
+
 // SwapCharactersBeforeCursor swaps the last two characters before the cursor.
 func (b *Buffer) SwapCharactersBeforeCursor() {
 	if b.cursorPosition >= 2 {

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/confluentinc/go-prompt
 
-go 1.21
+go 1.22.3
 
 require (
 	github.com/mattn/go-colorable v0.1.7
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/mattn/go-tty v0.0.3
 	github.com/pkg/term v1.2.0-beta.2
+	github.com/samber/lo v1.39.0
+	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/sys v0.6.0
 	pgregory.net/rapid v0.5.5
@@ -16,8 +18,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/samber/lo v1.39.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
-	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -35,3 +35,115 @@ func TestClearDiagnosticsOnTextChange(t *testing.T) {
 	p.ClearDiagnosticsOnTextChange()
 	require.NotNil(t, p.diagnostics)
 }
+
+func TestCompleteOnDown(t *testing.T) {
+	p := &Prompt{
+		completionOnDown: true,
+		buf:              NewBuffer(),
+		history:          &History{},
+	}
+	require.True(t, p.completeOnDown())
+
+	// Do not complete because completionOnDown is false
+	p = &Prompt{
+		completionOnDown: false,
+		buf:              NewBuffer(),
+		history:          &History{},
+	}
+	require.False(t, p.completeOnDown())
+
+	// Do not complete because history is active (select < len(tmp) - 1)
+	p = &Prompt{
+		completionOnDown: true,
+		buf:              NewBuffer(),
+		history: &History{
+			tmp:      []string{"foo", "bar"},
+			selected: 0,
+		},
+	}
+	require.False(t, p.completeOnDown())
+
+	// Do not complete because buf has next line that we can navigate to
+	b := NewBuffer()
+	b.InsertText("first line", false, false)
+	b.NewLine(true)
+	b.InsertText("second line", false, false)
+	b.setCursorPosition(0)
+
+	p = &Prompt{
+		completionOnDown: true,
+		buf:              b,
+		history:          &History{},
+	}
+	require.False(t, p.completeOnDown())
+
+	// Do not complete because all three conditions are false
+	p = &Prompt{
+		completionOnDown: false,
+		buf:              b,
+		history: &History{
+			tmp:      []string{"foo", "bar"},
+			selected: 0,
+		},
+	}
+	require.False(t, p.completeOnDown())
+}
+
+func TestHandleCompletionKeyBinding(t *testing.T) {
+	p := &Prompt{
+		renderer: &Render{},
+		completion: &CompletionManager{
+			selected:       0,
+			verticalScroll: 1,
+			tmp: []Suggest{
+				{Text: "foo", Description: "foo description"},
+			},
+		},
+	}
+
+	p.handleCompletionKeyBinding(Down, false)
+	require.False(t, p.renderer.hideCompletion)
+	require.Equal(t, p.completion.selected, 0)
+	require.Equal(t, p.completion.verticalScroll, 1)
+	require.Equal(t, len(p.completion.tmp), 1)
+
+	p.handleCompletionKeyBinding(Escape, false)
+	require.True(t, p.renderer.hideCompletion)
+	require.Equal(t, p.completion.selected, -1)
+	require.Equal(t, p.completion.verticalScroll, 0)
+	require.Equal(t, len(p.completion.tmp), 0)
+}
+
+func TestFeedEscape(t *testing.T) {
+	p := &Prompt{
+		completionOnDown: true,
+		buf:              NewBuffer(),
+		history:          &History{},
+		renderer:         &Render{},
+		completion: &CompletionManager{
+			selected:       0,
+			verticalScroll: 1,
+			tmp: []Suggest{
+				{Text: "foo", Description: "foo description"},
+			},
+		},
+	}
+	require.False(t, p.renderer.hideCompletion)
+	require.Equal(t, p.completion.selected, 0)
+	require.Equal(t, p.completion.verticalScroll, 1)
+	require.Equal(t, len(p.completion.tmp), 1)
+
+	key := []byte{0x1b} // {Key: Escape, ASCIICode: []byte{0x1b}}
+	p.feed(key)
+	require.True(t, p.renderer.hideCompletion)
+	require.Equal(t, p.completion.selected, -1)
+	require.Equal(t, p.completion.verticalScroll, 0)
+	require.Equal(t, len(p.completion.tmp), 0)
+
+	key = []byte{0x40} // We need to send something not mapped, for example Space, ASCIICode 64, Hex 0x40
+	p.feed(key)
+	require.False(t, p.renderer.hideCompletion)
+	require.Equal(t, p.completion.selected, -1)
+	require.Equal(t, p.completion.verticalScroll, 0)
+	require.Equal(t, len(p.completion.tmp), 0)
+}

--- a/render.go
+++ b/render.go
@@ -19,8 +19,8 @@ type Render struct {
 	title              string
 	row                uint16
 	col                uint16
-
-	previousCursor int
+	hideCompletion     bool
+	previousCursor     int
 
 	// colors,
 	prefixTextColor              Color
@@ -92,12 +92,13 @@ func (r *Render) UpdateWinSize(ws *WinSize) {
 
 // Render completions in the dropdown and returns the lenth that the cursor has to be moved back
 func (r *Render) renderCompletion(completions *CompletionManager, cursorPos int) int {
-	completionsSelectedIdx := completions.GetSelectedIdx()
-	completionsVerticalScroll := completions.GetVerticalScroll()
 	suggestions := completions.GetSuggestions()
-	if len(suggestions) == 0 {
+	if len(suggestions) == 0 || r.hideCompletion {
 		return 0
 	}
+
+	completionsSelectedIdx := completions.GetSelectedIdx()
+	completionsVerticalScroll := completions.GetVerticalScroll()
 	prefix := r.getCurrentPrefix()
 	formatted, width := formatSuggestions(
 		suggestions,


### PR DESCRIPTION
* feat: escape closes autocompletion

* fix: navigating with arrow down with multiline statements

* tiny refactor

* test: add tests for escape handling

* test: add tests for completing on arrow down

* chore: update go version

* undo: change go-version

* nit: call NewLineCount once