### PR TITLE
Change codeowners with ownership transition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/cloud-surfaces @confluentinc/flink-sql
+*	@confluentinc/cli


### PR DESCRIPTION
As discussed and agreed we've moving back the ownership as of May of 2025.